### PR TITLE
Schema fix

### DIFF
--- a/models/model_field.php
+++ b/models/model_field.php
@@ -79,15 +79,21 @@ namespace adapt{
                     $schema[$this->_data['table_name']] = [];
                 }
                 
-                $table_schema = $schema[$this->table_name];
+                $table_schema = $schema[$this->_data['table_name']];
                 $new_table_schema = [];
                 
+                $appended = false;
                 foreach($table_schema as $field_schema){
                     if ($field_schema['field_name'] == $this->field_name){
                         $new_table_schema[] = $this->to_hash()['field'];
+                        $appended = true;
                     }else{
                         $new_table_schema[] = $field_schema;
                     }
+                }
+                
+                if (!$appended) {
+                    $new_table_schema[] = $this->to_hash()['field'];
                 }
                 
                 $schema[$this->_data['table_name']] = $new_table_schema;

--- a/models/model_field.php
+++ b/models/model_field.php
@@ -90,7 +90,7 @@ namespace adapt{
                     }
                 }
                 
-                $schema[$this->table_name] = $new_table_schema;
+                $schema[$this->_data['table_name']] = $new_table_schema;
                 
                 $this->data_source->schema = $schema;
                 

--- a/models/model_field.php
+++ b/models/model_field.php
@@ -78,7 +78,20 @@ namespace adapt{
                 if (!is_array($schema[$this->_data['table_name']])){
                     $schema[$this->_data['table_name']] = [];
                 }
-                $schema[$this->_data['table_name']][] = $this->to_hash()['field'];
+                
+                $table_schema = $schema[$this->table_name];
+                $new_table_schema = [];
+                
+                foreach($table_schema as $field_schema){
+                    if ($field_schema['field_name'] == $this->field_name){
+                        $new_table_schema[] = $this->to_hash()['field'];
+                    }else{
+                        $new_table_schema[] = $field_schema;
+                    }
+                }
+                
+                $schema[$this->table_name] = $new_table_schema;
+                
                 $this->data_source->schema = $schema;
                 
                 return true;


### PR DESCRIPTION
This fix prevents the schema from duplicating fields during the update process.

The issue is non-obvious because the field table is always correct without any duplication but the data_source->schema property contains the duplication during the update, causing random failures.